### PR TITLE
Add support for floating point constants like 1.2

### DIFF
--- a/syntax/souffle.vim
+++ b/syntax/souffle.vim
@@ -26,7 +26,7 @@ syn match   souffleTypeKey       "^\.\(type\|number_type\|symbol_type\)" contain
 syn match   souffleRelId        "[a-zA-Z?_][a-zA-Z0-9?_][a-zA-Z0-9?_]*\|[a-zA-Z?]" contained containedin=souffleDefRel,souffleIORelNames,souffleRuleHead,souffleRuleBodyTerm
 syn match   souffleVarId        "[a-zA-Z?_][a-zA-Z0-9?_]*" contained containedin=souffleDefCName,souffleRuleHeadBody,souffleRuleTBody
 syn match   souffleTypeId       "[a-zA-Z?_][a-zA-Z0-9?_][a-zA-Z0-9?_]*\|[a-zA-Z?]" contained containedin=souffleTypeHead,souffleDefCType
-syn match   souffleConstantId   "\"[^\"]*\"\|\d\+\|\d\+\.\d\+" contained containedin=souffleRuleBody
+syn match   souffleConstantId   "\"[^\"]*\"\|[0-9][0-9]*\|[0-9][0-9]*\.[0-9][0-9]*" contained containedin=souffleRuleBody
 
 " Operators
 syn match souffleOp             "+\|-\|\*\|/\|<\|>\|=\|!" contained containedin=souffleRuleHeadBody,souffleRuleTBody,souffleRuleBody

--- a/syntax/souffle.vim
+++ b/syntax/souffle.vim
@@ -26,7 +26,7 @@ syn match   souffleTypeKey       "^\.\(type\|number_type\|symbol_type\)" contain
 syn match   souffleRelId        "[a-zA-Z?_][a-zA-Z0-9?_][a-zA-Z0-9?_]*\|[a-zA-Z?]" contained containedin=souffleDefRel,souffleIORelNames,souffleRuleHead,souffleRuleBodyTerm
 syn match   souffleVarId        "[a-zA-Z?_][a-zA-Z0-9?_]*" contained containedin=souffleDefCName,souffleRuleHeadBody,souffleRuleTBody
 syn match   souffleTypeId       "[a-zA-Z?_][a-zA-Z0-9?_][a-zA-Z0-9?_]*\|[a-zA-Z?]" contained containedin=souffleTypeHead,souffleDefCType
-syn match   souffleConstantId   "\"[^\"]*\"\|[0-9][0-9]*" contained containedin=souffleRuleBody
+syn match   souffleConstantId   "\"[^\"]*\"\|\d\+\|\d\+\.\d\+" contained containedin=souffleRuleBody
 
 " Operators
 syn match souffleOp             "+\|-\|\*\|/\|<\|>\|=\|!" contained containedin=souffleRuleHeadBody,souffleRuleTBody,souffleRuleBody
@@ -58,8 +58,8 @@ syn match   souffleDefCSep       ":" contained containedin=souffleDefCType
 syn match   souffleDefCType      ": *[a-zA-Z0-9?_-]*" contained containedin=souffleDefCName contains=souffleDefCSep,souffleTypeId
 
 " Rules
-syn region  souffleRule           start="[a-zA-Z0-9?_-]*(" end="\." contains=souffleRuleHead,souffleRuleBody keepend fold
-syn match   souffleRuleHead       "[a-zA-Z0-9?_-]*([^)]*)" contained containedin=souffleRule contains=souffleRelId,souffleRuleHeadBody keepend
+syn region  souffleRule           start="[a-zA-Z0-9?_-]*(" end="\." contains=souffleRuleHead,souffleRuleBody fold
+syn match   souffleRuleHead       "[a-zA-Z0-9?_-]*([^)]*)" contained containedin=souffleRule contains=souffleRelId,souffleRuleHeadBody
 syn match   souffleRuleHeadBody   "(.*)" contained containedin=souffleRuleHead contains=souffleVarId,souffleConstantId,souffleOp
 syn region  souffleRuleBody       start=":-" end="\." contained contains=souffleRuleBodyStart,souffleRuleBodyEnd,souffleRuleBodyTerm,souffleConstantId,souffleOp,souffleVarId keepend
 syn match   souffleRuleBodyStart  ":-" contained containedin=souffleRuleBody


### PR DESCRIPTION
Hey, idk, I thought this would be good, but I noticed that souffleRuleHead and souffleRule were marked with keepend, and I'm sure there's a decent reason why (but what is it? I want to know). Anyways if there isn't, then we can just take this PR as it is, otherwise let me know if there's anything else that can be done to enable floating point constant support in the souffle syntax highlighter without breaking other things. I couldn't see that removing keepend broke anything else.